### PR TITLE
Add support for 'Shortest Path' plugin

### DIFF
--- a/src/main/java/com/brastasauce/turaelskipping/SlayerTaskRegistry.java
+++ b/src/main/java/com/brastasauce/turaelskipping/SlayerTaskRegistry.java
@@ -89,7 +89,7 @@ public class SlayerTaskRegistry {
                                             new WorldPoint(2721, 5245, 0)
                                     )
                             ), new String[]{"Fairy ring: AJQ"})
-                    ), "Bring a light source")
+                    ), "Bring a light source", new WorldPoint(2715, 5235, 0))
             ),
             Map.entry("cave crawlers", new SlayerTask("Cave Crawlers", List.of(NpcID.SLAYER_CAVE_CRAWLER_1, NpcID.SLAYER_CAVE_CRAWLER_2, NpcID.SLAYER_CAVE_CRAWLER_3, NpcID.SLAYER_CAVE_CRAWLER_4), List.of(
                             new WorldPoint(2789, 3617, 0),
@@ -117,7 +117,7 @@ public class SlayerTaskRegistry {
                                             new WorldPoint(2735, 5239, 0)
                                     )
                             ), new String[]{"Fairy ring: AJQ"})
-                    ), "Bring a light source")
+                    ), "Bring a light source", new WorldPoint(2730, 5234, 0))
             ),
             // My preferred area for this task, keep it for when alternative locations are added
 //            Map.entry("cows", new SlayerTask("Cows", List.of(NpcID.AHOY_UNDEAD_COW), List.of(
@@ -231,7 +231,7 @@ public class SlayerTaskRegistry {
                                             new WorldPoint(3319, 9539, 0)
                                     )
                             ), new String[]{"Desert amulet 4: Kalphite cave"})
-                    ))
+                    ), new WorldPoint(3309, 9526, 0))
             ),
             Map.entry("lizards", new SlayerTask("Lizards", List.of(NpcID.SLAYER_LIZARD_SMALL2_SANDY, NpcID.SLAYER_LIZARD_SMALL1_GREEN), List.of(
                             new WorldPoint(3413, 3035, 0)
@@ -265,7 +265,8 @@ public class SlayerTaskRegistry {
                                             new WorldPoint(2332, 9163, 1)
                                     )
                             ), new String[]{"Gnome Glider: Ookookolly Undri"})
-                    ), "Run south and open the trapdoor, bring a light source")
+                    ), "Run south and open the trapdoor, bring a light source",
+                            new WorldPoint(2715, 2788, 0))
             ),
             Map.entry("rats", new SlayerTask("rats", List.of(NpcID.RAT, NpcID.DUNGEON_RAT), List.of(
                             new WorldPoint(3240, 3458, 0),

--- a/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingConfig.java
+++ b/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingConfig.java
@@ -76,6 +76,18 @@ public interface TuraelSkippingConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            position = 1,
+            keyName = "useShortestPath",
+            name = "Use 'Shortest Path' plugin",
+            description = "Draws the shortest path to the assigned task.<br/>" +
+                    "The 'Shortest Path' plugin needs to be installed and enabled for this to work.",
+            section = generalSettings
+    )
+    default boolean useShortestPath() {
+        return false;
+    }
+
     // Highlight settings
     @ConfigSection(
             position = 1,

--- a/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
+++ b/src/main/java/com/brastasauce/turaelskipping/TuraelSkippingPlugin.java
@@ -55,10 +55,12 @@ import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.npcoverlay.HighlightedNpc;
 import net.runelite.client.game.npcoverlay.NpcOverlayService;
+import net.runelite.client.events.PluginMessage;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -69,8 +71,10 @@ import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -123,6 +127,9 @@ public class TuraelSkippingPlugin extends Plugin {
 
     @Inject
     private SlayerTaskOverlay slayerTaskOverlay;
+
+    @Inject
+    private EventBus eventBus;
 
     @Getter
     private SlayerTask currentSlayerTask;
@@ -363,6 +370,11 @@ public class TuraelSkippingPlugin extends Plugin {
                 }
             }
 
+            if (config.useShortestPath()) {
+                WorldPoint location = currentSlayerTask.getShortestPathWorldPoint();
+                setShortestPath(location);
+            }
+
             // Target NPC's visible to the player in case they are already at the location
             Player player = client.getLocalPlayer();
 
@@ -407,6 +419,16 @@ public class TuraelSkippingPlugin extends Plugin {
         }
 
         return null;
+    }
+
+    private void setShortestPath(WorldPoint target) {
+        if (target == null){
+            return;
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("target", target);
+        eventBus.post(new PluginMessage("shortestpath", "path", data));
     }
 
     public Function<NPC, HighlightedNpc> npcHighlighter = (n) -> {

--- a/src/main/java/com/brastasauce/turaelskipping/models/SlayerTask.java
+++ b/src/main/java/com/brastasauce/turaelskipping/models/SlayerTask.java
@@ -36,6 +36,7 @@ public class SlayerTask {
     private final List<WorldPoint> worldMapLocations;
     private final List<NpcLocation> locations;
     private final String information;
+    private final WorldPoint shortestPathWorldPoint;
 
     public SlayerTask(String name, List<Integer> npcIds, List<WorldPoint> worldMapLocations, List<NpcLocation> locations) {
         this.name = name;
@@ -43,6 +44,7 @@ public class SlayerTask {
         this.worldMapLocations = worldMapLocations;
         this.locations = locations;
         this.information = null;
+        this.shortestPathWorldPoint = worldMapLocations.get(worldMapLocations.size() - 1);
     }
 
     public SlayerTask(String name, List<Integer> npcIds, List<WorldPoint> worldMapLocations, List<NpcLocation> locations, String information) {
@@ -51,5 +53,24 @@ public class SlayerTask {
         this.worldMapLocations = worldMapLocations;
         this.locations = locations;
         this.information = information;
+        this.shortestPathWorldPoint = worldMapLocations.get(worldMapLocations.size() - 1);
+    }
+
+    public SlayerTask(String name, List<Integer> npcIds, List<WorldPoint> worldMapLocations, List<NpcLocation> locations, WorldPoint shortestPathWorldPoint) {
+        this.name = name;
+        this.npcIds = npcIds;
+        this.worldMapLocations = worldMapLocations;
+        this.locations = locations;
+        this.information = null;
+        this.shortestPathWorldPoint = shortestPathWorldPoint;
+    }
+
+    public SlayerTask(String name, List<Integer> npcIds, List<WorldPoint> worldMapLocations, List<NpcLocation> locations, String information, WorldPoint shortestPathWorldPoint) {
+        this.name = name;
+        this.npcIds = npcIds;
+        this.worldMapLocations = worldMapLocations;
+        this.locations = locations;
+        this.information = information;
+        this.shortestPathWorldPoint = shortestPathWorldPoint;
     }
 }


### PR DESCRIPTION
Added a toggle for using the 'Shortest Path' plugin, uses the last set of coordinates from the "worldMapLocations" as the destination. In cases where these didn't work I added specific coordinates in the SlayerTaskRegistry.